### PR TITLE
Add a makefile to make it easier to build and install the extension.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 *.swp
+_build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Basic Makefile
+
+# Retrieve the UUID from ``metadata.json``
+UUID = $(shell grep -E '^[ ]*"uuid":' ./metadata.json | sed 's@^[ ]*"uuid":[ ]*"\(.\+\)",[ ]*@\1@')
+BASE_MODULES = extension.js metadata.json COPYING README.md
+EXTRA_MODULES = lib.js prefs.js
+MSGSRC = $(wildcard locale/*/*/*.po)
+INSTALLBASE = ~/.local/share/gnome-shell/extensions
+INSTALLNAME = $(UUID)
+
+$(info UUID is "$(UUID)")
+
+.PHONY: all _build clean extension install install-local zip-file
+
+all: extension
+
+clean:
+	rm -f ./schemas/gschemas.compiled
+	rm -f ./locale/*/*/*.mo
+	-rm -fR ./_build
+
+extension: ./schemas/gschemas.compiled $(MSGSRC:.po=.mo)
+
+./schemas/gschemas.compiled: ./schemas/org.gnome.shell.extensions.suspend-button.gschema.xml
+	glib-compile-schemas ./schemas/
+
+./locale/%.mo: ./locale/%.po
+	msgfmt -c $< -o $@
+
+install: install-local
+
+install-local: _build
+	rm -rf $(INSTALLBASE)/$(INSTALLNAME)
+	mkdir -p $(INSTALLBASE)/$(INSTALLNAME)
+	cp -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
+
+zip-file: _build
+	cd _build ; \
+	zip -qr "$(UUID)$(VSTRING).zip" .
+	mv _build/$(UUID)$(VSTRING).zip ./
+
+_build: all
+	-rm -fR ./_build
+	mkdir -p _build
+	cp $(BASE_MODULES) $(EXTRA_MODULES) _build
+	mkdir -p _build/schemas
+	cp schemas/*.xml _build/schemas/
+	cp schemas/gschemas.compiled _build/schemas/
+	cp -r locale _build/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@ gnome-shell-extension-suspend-button
 ====================================
 
 GNOME Shell Extension Suspend-Button for GNOME 3.10 / 3.12 / 3.14 / 3.16 / 3.18
+
+
+Installation
+============
+
+Run
+
+```
+make
+make install
+```
+
+This will build and install the extension to ``~/.local/share/gnome-shell/extensions/``.


### PR DESCRIPTION
The makefile is based on the ``Makefile`` used by the dash-to-dock
extension.