### PR TITLE
Use `system-suspend` for Suspend icon instead of `media-playback-pause`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gnome-shell-extension-suspend-button
 ====================================
 
-GNOME Shell Extension Suspend-Button for GNOME 3.10 / 3.12 / 3.14 / 3.16 / 3.18 / 3.20 / 3.22
+GNOME Shell Extension Suspend-Button for GNOME 3.10 / 3.12 / 3.14 / 3.16 / 3.18 / 3.20 / 3.22 / 3.24 / 3.26
 
 
 Installation

--- a/extension.js
+++ b/extension.js
@@ -20,10 +20,13 @@ const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 
+const Config = imports.misc.config;
+
 const LoginManager = imports.misc.loginManager;
 const Main = imports.ui.main;
 const StatusSystem = imports.ui.status.system;
 const PopupMenu = imports.ui.popupMenu;
+const BoxPointer = imports.ui.boxpointer;
 const ExtensionSystem = imports.ui.extensionSystem;
 
 const SHOW_TWO_BUTTONS = 'show-two-buttons';
@@ -185,11 +188,25 @@ const Extension = new Lang.Class({
     },
     
     _onPowerOffClicked: function() {
-        this.systemMenu._onPowerOffClicked()
+        gnomeShellVersion = Config.PACKAGE_VERSION.split(".")
+        if (gnomeShellVersion[0] == 3 && gnomeShellVersion[1] > 24) {
+            this.systemMenu.menu.itemActivated(BoxPointer.PopupAnimation.NONE);
+            this.systemMenu._systemActions.activatePowerOff()
+        }
+	else {
+            this.systemMenu._onPowerOffClicked()
+        }
     },
 
     _onSuspendClicked: function() {
-        this.systemMenu._onSuspendClicked();
+        gnomeShellVersion = Config.PACKAGE_VERSION.split(".")
+        if (gnomeShellVersion[0] == 3 && gnomeShellVersion[1] > 24) {
+	    this.systemMenu.menu.itemActivated(BoxPointer.PopupAnimation.NONE);
+            this.systemMenu._systemActions.activateSuspend()
+        }
+	else {
+            this.systemMenu._onSuspendClicked()
+        }
     }
 });
 

--- a/extension.js
+++ b/extension.js
@@ -129,7 +129,7 @@ const Extension = new Lang.Class({
     },
     
     _createActions: function() {
-        this._altsuspendAction = this.systemMenu._createActionButton('media-playback-pause-symbolic', _("Suspend"));
+        this._altsuspendAction = this.systemMenu._createActionButton('system-suspend-symbolic', _("Suspend"));
         this._altsuspendActionID = this._altsuspendAction.connect('clicked', Lang.bind(this, this._onSuspendClicked));
 
         this._altpowerOffAction = this.systemMenu._createActionButton('system-shutdown-symbolic', _("Power Off"));

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,9 @@
     "3.16",
     "3.18",
     "3.20",
-    "3.22"
+    "3.22",
+    "3.24",
+    "3.26"
   ],
   "url": "https://github.com/laserb/gnome-shell-extension-suspend-button",
   "uuid": "suspend-button@laserb",


### PR DESCRIPTION
Although GNOME Shell uses the pause icon when you press Alt with the menu open, I think that a seperate button should use the correct icon, per the freedesktop specifications.