### PR TITLE
Gnome shell version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gnome-shell-extension-suspend-button
 ====================================
 
-GNOME Shell Extension Suspend-Button for GNOME 3.10 / 3.12 / 3.14 / 3.16 / 3.18 / 3.20 / 3.22
+GNOME Shell Extension Suspend-Button for GNOME 3.10 / 3.12 / 3.14 / 3.16 / 3.18 / 3.20 / 3.22 / 3.24
 
 
 Installation

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
     "3.16",
     "3.18",
     "3.20",
-    "3.22"
+    "3.22",
+    "3.24"
   ],
   "url": "https://github.com/laserb/gnome-shell-extension-suspend-button",
   "uuid": "suspend-button@laserb",


### PR DESCRIPTION
This extension works well with gnome-shell version 3.24.2
Update the corresponding files.

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>